### PR TITLE
Added dependencies needed to create distribution

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,3 +7,7 @@ on 'test' => sub {
     requires 'Devel::Cover';
 };
 
+on 'develop' => sub {
+    requires 'Minilla';
+    requires 'Software::License::Artistic_2_0';
+};


### PR DESCRIPTION
Both Minilla and Software::License::Artistic_2_0 are required to
create dists for this plugin. Added these as requirements in the
develop-phase of `cpanfile`. Installed by `cpanm --with-develop
--installdeps .`

Closes tyldum/mojolicious-plugin-prometheus#7