### PR TITLE
Add worker label to HTTP metrics

### DIFF
--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -29,7 +29,7 @@ sub register {
       subsystem => $config->{subsystem}        // undef,
       name      => "http_request_duration_seconds",
       help      => "Histogram with request processing time",
-      labels    => [qw/method worker/],
+      labels    => [qw/worker method/],
       buckets   => $config->{duration_buckets} // undef,
     )
   );
@@ -40,7 +40,7 @@ sub register {
       subsystem => $config->{subsystem} // undef,
       name      => "http_request_size_bytes",
       help      => "Histogram containing request sizes",
-      labels    => [qw/method worker/],
+      labels    => [qw/worker method/],
       buckets   => $config->{request_buckets}
         // [(1, 50, 100, 1_000, 10_000, 50_000, 100_000, 500_000, 1_000_000)],
     )
@@ -52,7 +52,7 @@ sub register {
       subsystem => $config->{subsystem} // undef,
       name      => "http_response_size_bytes",
       help      => "Histogram containing response sizes",
-      labels    => [qw/method code worker/],
+      labels    => [qw/worker method code/],
       buckets   => $config->{response_buckets}
         // [(5, 50, 100, 1_000, 10_000, 50_000, 100_000, 500_000, 1_000_000)],
     )
@@ -65,7 +65,7 @@ sub register {
       name      => "http_requests_total",
       help =>
         "How many HTTP requests processed, partitioned by status code and HTTP method.",
-      labels => [qw/method code worker/],
+      labels => [qw/worker method code/]
     )
   );
 
@@ -81,25 +81,25 @@ sub register {
     before_dispatch => sub {
       my ($c) = @_;
       $c->stash('prometheus.start_time' => [gettimeofday]);
-      $self->http_request_size_bytes->observe($c->req->method,
-        $c->req->content->asset->size, $$);
+      $self->http_request_size_bytes->observe($$, $c->req->method,
+        $c->req->content->asset->size);
     }
   );
 
   $app->hook(
     after_render => sub {
       my ($c) = @_;
-      $self->http_request_duration_seconds->observe($c->req->method,
-        tv_interval($c->stash('prometheus.start_time')), $$);
+      $self->http_request_duration_seconds->observe($$, $c->req->method,
+        tv_interval($c->stash('prometheus.start_time')));
     }
   );
 
   $app->hook(
     after_dispatch => sub {
       my ($c) = @_;
-      $self->http_requests_total->inc($c->req->method, $c->res->code, $$);
-      $self->http_response_size_bytes->observe($c->req->method, $c->res->code,
-        $c->res->content->asset->size, $$);
+      $self->http_requests_total->inc($$, $c->req->method, $c->res->code);
+      $self->http_response_size_bytes->observe($$, $c->req->method, $c->res->code,
+        $c->res->content->asset->size);
     }
   );
 

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -5,7 +5,7 @@ use Net::Prometheus;
 
 our $VERSION = '1.0.4';
 
-has prometheus => sub { state $prom = Net::Prometheus->new };
+has prometheus => sub { state $prom = _init_prometheus() };
 has route => sub {undef};
 has http_request_duration_seconds => sub {
   undef;
@@ -19,6 +19,13 @@ has http_response_size_bytes => sub {
 has http_requests_total => sub {
   undef;
 };
+
+sub _init_prometheus {
+  my $prom = Net::Prometheus->new(disable_process_collector => 1);
+  my $process_collector = Net::Prometheus::ProcessCollector->new(labels => [ worker => $$ ]);
+  $prom->register($process_collector);
+  return $prom;
+}
 
 sub register {
   my ($self, $app, $config) = @_;

--- a/t/basic.t
+++ b/t/basic.t
@@ -23,6 +23,6 @@ $t->post_ok('/' => json => {hello => 'somedata'})->status_is(200)
   ->content_is('Hello Mojo!');
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-  ->content_like(qr/http_request_duration_seconds_count\{method="GET"\} 1/);
+  ->content_like(qr/http_request_duration_seconds_count\{worker="\d+",method="GET"\} 1/);
 
 done_testing();

--- a/t/custom_buckets.t
+++ b/t/custom_buckets.t
@@ -16,6 +16,6 @@ my $t = Test::Mojo->new;
 $t->get_ok('/')->status_is(200)->content_like(qr/Hello Mojo!/);
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-  ->content_like(qr/http_request_size_bytes_count\{method="GET"\} 2/);
+  ->content_like(qr/http_request_size_bytes_count\{worker="\d+",method="GET"\} 2/);
 
 done_testing();

--- a/t/defaults.t
+++ b/t/defaults.t
@@ -26,9 +26,9 @@ for my $i (1 .. 100) {
 }
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-  ->content_like(qr/http_requests_total\{method="GET",code="200"\} 100/);
+  ->content_like(qr/http_requests_total\{worker="\d+",method="GET",code="200"\} 100/);
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-  ->content_like(qr/http_request_duration_seconds_count\{method="GET"\} 101/);
+  ->content_like(qr/http_request_duration_seconds_count\{worker="\d+",method="GET"\} 101/);
 
 done_testing();

--- a/t/linux.t
+++ b/t/linux.t
@@ -17,7 +17,7 @@ if ($^O eq 'linux') {
 
   # Only Linux supported by Net::Prometheus process collector
   $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-    ->content_like(qr/process_cpu_seconds_total/);
+    ->content_like(qr/process_cpu_seconds_total\{worker="\d+"/);
 }
 else {
   plan skip_all => 'Test irrelevant outside Linux';


### PR DESCRIPTION
Add additional worker label to HTTP metrics to distinguish workers and allow for correct aggregation in Prometheus. This will at least partially resolve issue #13 .

The process metrics supplied by Net::Prometheus::ProcessCollector do not add the process id yet.