### PR TITLE
Prefix route for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Register plugin in [Mojolicious](https://metacpan.org/pod/Mojolicious) applicati
 
     Key used for shared memory access between workers, see [$key in IPc::ShareLite](https://metacpan.org/pod/IPC::ShareLite) for details.
 
+- route
+
+    [Mojolicious::Routes::Route](https://metacpan.org/pod/Mojolicious::Routes::Route) object to attach the metrics to, defaults to generating a new one for '/'.
+
+
 # METRICS
 
 In addition to exposing the default process metrics that [Net::Prometheus](https://metacpan.org/pod/Net::Prometheus) already expose

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -119,7 +119,7 @@ sub register {
   );
 
 
-  my $prefix = $config->{route} // $app->routes->get('/');
+  my $prefix = $config->{route} // $app->routes->under('/');
   $self->route($prefix->get($config->{path} // '/metrics'));
   $self->route->to(
     cb => sub {

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -119,7 +119,8 @@ sub register {
   );
 
 
-  $self->route($app->routes->get($config->{path} // '/metrics'));
+  my $prefix = $config->{route} // $app->routes->get('/');
+  $self->route($prefix->get($config->{path} // '/metrics'));
   $self->route->to(
     cb => sub {
       my ($c) = @_;

--- a/t/custom_route.t
+++ b/t/custom_route.t
@@ -1,0 +1,23 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojolicious::Lite;
+use Test::Mojo;
+
+
+my $t = Test::Mojo->new;
+
+my $under = app->routes->under('/secret' =>sub {
+  my $c = shift;
+  return 1 if $c->req->url->to_abs->userinfo eq 'Bender:rocks';
+  $c->res->headers->www_authenticate('Basic');
+  $c->render(text => 'Authentication required!', status => 401);
+  return undef;
+});
+
+plugin Prometheus => {route => $under};
+
+$t->get_ok('//Bender:rocks@/secret/metrics')->status_is(200)->content_type_like(qr(^text/plain))
+  ->content_like(qr/http_request_duration_seconds/);
+
+done_testing();


### PR DESCRIPTION
I think it's good idea to give the opportunity to create prefix-route for metrics. This can help when setting up basic auth.