### PR TITLE
Added a new Perl-collector and made sure all collectors separate by worker process

### DIFF
--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -38,14 +38,14 @@ has config => sub {
       labels  => [qw/worker method code/],
       cb      => sub($c) { $$, $c->req->method, $c->res->code },
     },
-		perl_collector => {
-			enabled   => 1,
-			labels_cb => sub { { worker => $$ } },
-		},
-		process_collector => {
-			enabled   => 1,
-			labels_cb => sub { { worker => $$ } },
-		},
+    perl_collector => {
+      enabled   => 1,
+      labels_cb => sub { { worker => $$ } },
+    },
+    process_collector => {
+      enabled   => 1,
+      labels_cb => sub { { worker => $$ } },
+    },
   }
 };
 

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -1,13 +1,14 @@
 package Mojolicious::Plugin::Prometheus;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
-use Time::HiRes qw/gettimeofday tv_interval/;
-use Net::Prometheus;
+use Mojolicious::Plugin::Prometheus::Collector::Perl;
 use IPC::ShareLite;
+use Net::Prometheus;
+use Time::HiRes qw/gettimeofday tv_interval/;
 
 our $VERSION = '1.4.1';
 
-has prometheus => sub { Net::Prometheus->new(disable_process_collector => 1) };
-has route => sub {undef};
+has prometheus => \&_prometheus;
+has route => sub { undef };
 
 # Attributes to hold the different metrics that are registered
 has http_request_duration_seconds => sub { undef };
@@ -37,11 +38,19 @@ has config => sub {
       labels  => [qw/worker method code/],
       cb      => sub($c) { $$, $c->req->method, $c->res->code },
     },
+		perl_collector => {
+			enabled   => 1,
+			labels_cb => sub { { worker => $$ } },
+		},
+		process_collector => {
+			enabled   => 1,
+			labels_cb => sub { { worker => $$ } },
+		},
   }
 };
 
 sub register($self, $app, $config = {}) {
-  $self->{key} = $config->{shm_key} || '12345';
+  $self->{key} = $config->{shm_key} || $$;
 
   for(keys $self->config->%*) {
     next unless $config->{$_};
@@ -161,10 +170,11 @@ sub _start {
 
   Mojo::IOLoop->next_tick(
     sub {
-      my $pc = Net::Prometheus::ProcessCollector->new(labels => [worker => $$]);
-      $self->prometheus->register($pc) if $pc;
+			my $labels    = $self->config->{process_collector}{labels_cb}->();
+      my $collector = Net::Prometheus::ProcessCollector->new(labels => [%$labels]);
+      $self->prometheus->register($collector);
     }
-  );
+  ) if $self->config->{process_collector}{enabled};
 
   # Remove stopped workers
   $server->on(
@@ -174,6 +184,17 @@ sub _start {
     }
   ) if $server->isa('Mojo::Server::Prefork');
 }
+
+sub _prometheus($self) {
+	my $prometheus = Net::Prometheus->new(disable_process_collector => 1, disable_perl_collector => 1);
+
+	if($self->config->{perl_collector}{enabled}) {
+		my $perl_collector = Mojolicious::Plugin::Prometheus::Collector::Perl->new($self->config->{perl_collector});
+		$prometheus->register($perl_collector);
+	}
+
+	$prometheus;
+};
 
 package Mojolicious::Plugin::Mojolicious::_Guard;
 use Mojo::Base -base;
@@ -226,7 +247,6 @@ Mojolicious::Plugin::Prometheus - Mojolicious Plugin
 
   # Mojolicious::Lite, with custom response buckets and metrics pr endpoint
   plugin 'Prometheus' => {
-    shm_key => $$,
     http_requests_total => {
       buckets => [qw/4 5 6/],
       labels  => [qw/worker method endpoint code/],
@@ -298,7 +318,7 @@ These will be prefixed to the metrics exported.
 
 =item * shm_key
 
-Key used for shared memory access between workers, see L<$key in IPc::ShareLite|https://metacpan.org/pod/IPC::ShareLite> for details.
+Key used for shared memory access between workers, see L<$key in IPc::ShareLite|https://metacpan.org/pod/IPC::ShareLite> for details. Default is the process id read from C<$$>.
 
 =item * http_request_duration_seconds
 
@@ -315,6 +335,48 @@ Structure that overrides the configuration for the C<http_response_size_bytes> m
 =item * http_requests_total
 
 Structure that overrides the configuration for the C<http_requests_total> metric. See below.
+
+=item perl_collector
+
+Structure that tells the plugin to enable or disable a Perl collector. Previously the Perl collector from L<Net::Prometheus> was used, but that is no longer in use due to it not being possible to add dynamic label values. Now L<Mojolicious::Plugin::Prometheus::Collector::Perl> is used. The configuration here need as follows:
+
+=over 4
+
+=item enabled
+
+Boolean-ish value indicating if this collector should be used.
+
+=item labels_cb
+
+A subref that the collector can call to dynamically resolve which labels and corresponding label values should be added to each metric. Default is:
+
+  {
+    enabled   => 1,
+    labels_cb => sub { { worker => $$ } },
+  }
+
+=back
+
+=item process_collector
+
+Structure that tells the plugin to enable or disable a process collector. The process collector from L<Net::Prometheus> is used for this. The configuration here need as follows:
+
+=over 4
+
+=item enabled
+
+Boolean-ish value indicating if this collector should be used.
+
+=item labels_cb
+
+A subref that the collector can call to dynamically resolve which labels and corresponding label values should be added to each metric. Default is:
+
+  {
+    enabled   => 1,
+    labels_cb => sub { { worker => $$ } },
+  }
+
+=back
 
 =back
 
@@ -335,7 +397,7 @@ this plugin will also expose
 
 =back
 
-Custom configuration of the built in metrics is possible. An example structure can be seen in the synopsis. The four built in metrics from this plugin all have more or less the same structure. Metrics provided by the Perl- and Process-collectors from L<Net::Prometheus|https://metacpan.org/pod/Net::Prometheus> can be changed by providing a custom C<prometheus> object.
+Custom configuration of the built in metrics is possible. An example structure can be seen in the synopsis. The four built in metrics from this plugin all have more or less the same structure. Metrics provided by the Perl- and Process-collectors from L<Net::Prometheus|https://metacpan.org/pod/Net::Prometheus> can be used and changed by providing a custom C<prometheus> object instead of using the defaults as detailed previously.
 
 Default configuration for the built in metrics are as follows:
 

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -318,7 +318,7 @@ These will be prefixed to the metrics exported.
 
 =item * shm_key
 
-Key used for shared memory access between workers, see L<$key in IPc::ShareLite|https://metacpan.org/pod/IPC::ShareLite> for details. Default is the process id read from C<$$>.
+Key used for shared memory access between workers, see L<$key in IPC::ShareLite|https://metacpan.org/pod/IPC::ShareLite> for details. Default is the process id read from C<$$>.
 
 =item * http_request_duration_seconds
 

--- a/lib/Mojolicious/Plugin/Prometheus.pm
+++ b/lib/Mojolicious/Plugin/Prometheus.pm
@@ -170,7 +170,7 @@ sub _start {
 
   Mojo::IOLoop->next_tick(
     sub {
-			my $labels    = $self->config->{process_collector}{labels_cb}->();
+      my $labels    = $self->config->{process_collector}{labels_cb}->();
       my $collector = Net::Prometheus::ProcessCollector->new(labels => [%$labels]);
       $self->prometheus->register($collector);
     }
@@ -186,14 +186,14 @@ sub _start {
 }
 
 sub _prometheus($self) {
-	my $prometheus = Net::Prometheus->new(disable_process_collector => 1, disable_perl_collector => 1);
+  my $prometheus = Net::Prometheus->new(disable_process_collector => 1, disable_perl_collector => 1);
 
-	if($self->config->{perl_collector}{enabled}) {
-		my $perl_collector = Mojolicious::Plugin::Prometheus::Collector::Perl->new($self->config->{perl_collector});
-		$prometheus->register($perl_collector);
-	}
+  if($self->config->{perl_collector}{enabled}) {
+    my $perl_collector = Mojolicious::Plugin::Prometheus::Collector::Perl->new($self->config->{perl_collector});
+    $prometheus->register($perl_collector);
+  }
 
-	$prometheus;
+  $prometheus;
 };
 
 package Mojolicious::Plugin::Mojolicious::_Guard;

--- a/lib/Mojolicious/Plugin/Prometheus/Collector/Perl.pm
+++ b/lib/Mojolicious/Plugin/Prometheus/Collector/Perl.pm
@@ -1,0 +1,53 @@
+package Mojolicious::Plugin::Prometheus::Collector::Perl;
+use Mojo::Base -base, -signatures;
+use Mojo::Collection;
+use Net::Prometheus::Types qw( MetricSamples Sample );
+use Net::Prometheus::PerlCollector;
+
+has detail       => 0;
+has labels_cb    => sub {{}};
+has perl_version => sub { ( $^V =~ m/^v(.*)$/ )[0] };
+
+sub collect($self, $opts) {
+	my @samples = (
+		MetricSamples(
+			'perl_info',
+			gauge => 'Perl interpreter version',
+			[ Sample( 'perl_info', [ version => $self->perl_version, $self->labels_cb->()->%* ], 1 ) ]
+		),
+	);
+	return @samples unless Net::Prometheus::PerlCollector::HAVE_XS;
+
+	my ($arenas, $svs, $svs_by_type, $svs_by_class) = Net::Prometheus::PerlCollector::count_heap($self->detail);
+
+	push @samples, MetricSamples(
+		'perl_heap_arenas',
+		gauge => 'Number of arenas in the Perl heap',
+		[ Sample('perl_heap_arenas', [$self->labels_cb->()->%*], $arenas) ]
+	);
+	push @samples, MetricSamples(
+		'perl_heap_svs',
+		gauge => 'Number of SVs in the Perl heap',
+		[ Sample('perl_heap_svs', [$self->labels_cb->()->%*], $svs) ]
+	);
+
+	if($svs_by_type) {
+		my $by_type = Mojo::Collection->new(keys %$svs_by_type)
+			->sort
+			->map(sub { Sample('perl_heap_svs_by_type', [ type => $_, $self->labels_cb->()->%* ], $svs_by_type->{$_}) })
+			->to_array;
+		push @samples, MetricSamples('perl_heap_svs_by_type', gauge => 'Number of SVs classified by type', $by_type);
+	}
+
+	if($svs_by_class) {
+		my $by_class = Mojo::Collection->new(keys %$svs_by_class)
+			->sort
+			->map(sub { Sample('perl_heap_svs_by_class', [ class => $_, $self->labels_cb->()->%* ], $svs_by_class->{$_}) })
+			->to_array;
+		push @samples, MetricSamples('perl_heap_svs_by_class', gauge => 'Number of SVs classified by class', $by_class);
+	}
+
+	return @samples;
+}
+
+1;

--- a/t/custom_buckets.t
+++ b/t/custom_buckets.t
@@ -4,8 +4,11 @@ use Test::More;
 use Mojolicious::Lite;
 use Test::Mojo;
 
-plugin 'Prometheus' =>
-  {request_buckets => [qw/1 2 3/], response_buckets => [qw/4 5 6/],};
+plugin 'Prometheus' => {
+	http_request_size_bytes => {
+		buckets => [qw/1 2 3/],
+	},
+};
 
 get '/' => sub {
   my $c = shift;
@@ -16,6 +19,9 @@ my $t = Test::Mojo->new;
 $t->get_ok('/')->status_is(200)->content_like(qr/Hello Mojo!/);
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-  ->content_like(qr/http_request_size_bytes_count\{worker="\d+",method="GET"\} 1/);
+	->content_like(qr/http_request_size_bytes_count\{worker="\d+",method="GET"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="1"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="2"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="3"\} \d/);
 
 done_testing();

--- a/t/custom_buckets.t
+++ b/t/custom_buckets.t
@@ -5,9 +5,9 @@ use Mojolicious::Lite;
 use Test::Mojo;
 
 plugin 'Prometheus' => {
-	http_request_size_bytes => {
-		buckets => [qw/1 2 3/],
-	},
+	duration_buckets => [qw/1 2 3/],
+	request_buckets  => [qw/4 5 6/],
+	response_buckets => [qw/7 8 9/],
 };
 
 get '/' => sub {
@@ -19,9 +19,14 @@ my $t = Test::Mojo->new;
 $t->get_ok('/')->status_is(200)->content_like(qr/Hello Mojo!/);
 
 $t->get_ok('/metrics')->status_is(200)->content_type_like(qr(^text/plain))
-	->content_like(qr/http_request_size_bytes_count\{worker="\d+",method="GET"\} \d/)
-	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="1"\} \d/)
-	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="2"\} \d/)
-	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="3"\} \d/);
+	->content_like(qr/http_request_duration_seconds_bucket\{worker="\d+",method="GET",le="1"\} \d/)
+	->content_like(qr/http_request_duration_seconds_bucket\{worker="\d+",method="GET",le="2"\} \d/)
+	->content_like(qr/http_request_duration_seconds_bucket\{worker="\d+",method="GET",le="3"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="4"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="5"\} \d/)
+	->content_like(qr/http_request_size_bytes_bucket\{worker="\d+",method="GET",le="6"\} \d/)
+	->content_like(qr/http_response_size_bytes_bucket\{worker="\d+",method="GET",code="200",le="7"\} \d/)
+	->content_like(qr/http_response_size_bytes_bucket\{worker="\d+",method="GET",code="200",le="8"\} \d/)
+	->content_like(qr/http_response_size_bytes_bucket\{worker="\d+",method="GET",code="200",le="9"\} \d/);
 
 done_testing();


### PR DESCRIPTION
Since the original Perl collector from `Net::Prometheus` is somewhat limited in how labels can be provided I decided to create a new one with a more dynamic behaviour. Thus `Mojolicious::Plugin::Prometheus::Collector::Perl` was born. This PR solves the duplication issue as all metrics now report everything on a per worker-basis. The user can through the configuration choose not to do so.